### PR TITLE
Filename instead of Destination

### DIFF
--- a/backupwallet.html
+++ b/backupwallet.html
@@ -39,7 +39,7 @@
 Safely copies wallet.dat to destination filename
 
 Arguments:
-1. &#34;destination&#34;   (string, required) The destination filename, saved in the directory set by -exportdir option.
+1. &#34;filename&#34;   (string, required) The destination filename, saved in the directory set by -exportdir option.
 
 Result:
 &#34;path&#34;             (string) The full path of the destination file


### PR DESCRIPTION
It may be that is what is specified in the code, but filename is used for dumpwallet and is correct, destination is incorrect in this context as the destination is set by data dir.